### PR TITLE
Scroll to first error and add URL validation

### DIFF
--- a/src/pages/ProposalManagement.tsx
+++ b/src/pages/ProposalManagement.tsx
@@ -258,6 +258,18 @@ export const ProposalManagementPage = () => {
               layout="vertical"
               onFinish={handleFinish}
               requiredMark={false}
+              onFinishFailed={() => {
+                setTimeout(() => {
+                  const errorEl = document.querySelector(
+                    ".ant-form-item-has-error",
+                  );
+
+                  errorEl?.scrollIntoView({
+                    behavior: "smooth",
+                    block: "center",
+                  });
+                });
+              }}
             >
               <Stack $style={{ display: step === 1 ? "block" : "none" }}>
                 <Form.Item<Proposal>
@@ -351,6 +363,10 @@ export const ProposalManagementPage = () => {
                     {
                       required: step > 1,
                       message: "Please input your plugin server endpoint!",
+                    },
+                    {
+                      type: "url",
+                      message: "Please input a valid URL!",
                     },
                   ]}
                 >


### PR DESCRIPTION
Improve form UX by adding an onFinishFailed handler that scrolls smoothly to the first .ant-form-item-has-error element (uses setTimeout to wait for DOM updates). Also add a `type: "url"` validation rule for the plugin server endpoint input to ensure a valid URL is entered.